### PR TITLE
Log update

### DIFF
--- a/bevobeacon-iaq/connection.py
+++ b/bevobeacon-iaq/connection.py
@@ -8,6 +8,7 @@ GPIO.setmode(GPIO.BCM)
 GPIO.setwarnings(False)
 GPIO.setup(led_pin,GPIO.OUT)
 
+debug = False
 while True:
     ps = subprocess.Popen(['iwgetid'], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     try:
@@ -17,10 +18,11 @@ while True:
         # grep did not match any lines
         status = "Not Connected"
 
-    print(status)
+    if debug:
+        print(status)
     if status == "Connected":
         GPIO.output(led_pin,GPIO.HIGH)
     else:
         GPIO.output(led_pin,GPIO.LOW)
 
-    time.sleep(5)
+    time.sleep(60)

--- a/bevobeacon-iaq/display/display.py
+++ b/bevobeacon-iaq/display/display.py
@@ -44,7 +44,7 @@ def get_measurements(variables,path_to_data="/home/pi/DATA"):
         inner list corresponds to the variable, unit, and display name
     """
     # logging instance
-    logger = setup_logging("get_measurements")
+    logger = setup_logging("get_measurements",level=logging.ERROR)
     # getting newest file
     file_list = glob.glob(f"{path_to_data}/*.csv")
     newest_file = max(file_list, key=os.path.getctime)
@@ -154,7 +154,7 @@ def get_display_unit(param):
     else: # no change needed
         return param
 
-def setup_logging(log_file_name):
+def setup_logging(log_file_name,level):
     """
     Creates a logging object
 
@@ -162,6 +162,8 @@ def setup_logging(log_file_name):
     ----------
     log_file_name : str
         how to name the log file
+    level : logging level
+        priority level of messages to record
 
     Returns
     -------
@@ -171,21 +173,20 @@ def setup_logging(log_file_name):
     # Create a custom logger
     logger = logging.getLogger(__name__)
 
-    # Create handlers
-    c_handler = logging.StreamHandler()
+    # Clearing log instances
+    if logger.hasHandlers():
+        logger.handlers.clear()
+
+    # Create handler
     dir_path = pathlib.Path(__file__).resolve().parent
     f_handler = logging.FileHandler(f'{dir_path}/{log_file_name}.log',mode='w')
-    c_handler.setLevel(logging.WARNING)
-    f_handler.setLevel(logging.DEBUG)
+    logging.getLogger().setLevel(level)
 
-    # Create formatters and add it to handlers
-    c_format = logging.Formatter('%(asctime)s: %(name)s (%(lineno)d) - %(levelname)s - %(message)s',datefmt='%m/%d/%y %H:%M:%S')
-    f_format = logging.Formatter('%(asctime)s: %(name)s (%(lineno)d) - %(levelname)s - %(message)s',datefmt='%m/%d/%y %H:%M:%S')
-    c_handler.setFormatter(c_format)
+    # Create formatter and add it to handler
+    f_format = logging.Formatter('%(asctime)s: %(name)s (%(lineno)d) - %(levelname)s:\t%(message)s',datefmt='%m/%d/%y %H:%M:%S')
     f_handler.setFormatter(f_format)
 
-    # Add handlers to the logger
-    logger.addHandler(c_handler)
+    # Add handler to the logger
     logger.addHandler(f_handler)
 
     return logger

--- a/bevobeacon-iaq/main.py
+++ b/bevobeacon-iaq/main.py
@@ -28,7 +28,6 @@ from botocore.exceptions import ClientError
 
 async def main(beacon = '00'):
     # AWS credentials
-    print(os.environ)
     try:
         AWS_ACCESS_KEY_ID = os.environ['AWS_ACCESS_KEY_ID']
         AWS_SECRET_ACCESS_KEY = os.environ['AWS_SECRET_ACCESS_KEY']
@@ -199,27 +198,38 @@ def aws_s3_upload_file(s3,filename,s3_bucket,s3_filepath):
 		log.info(f"FileNotFoundError: {e}")
 
 def setup_logger(level=logging.WARNING):
-    """logging setup for standard and file output"""
+    """
+    Logging setup for standard and file output
+
+    Parameters
+    ----------
+    level : logging level
+        priority level of messages to record
+
+    Returns
+    -------
+    log : logging instance
+        file-based logger
+    """
+    # creating logging instance
     log = logging.getLogger(__name__)
-    log.setLevel(logging.INFO)
+
+    log.setLevel(level)
     log.propagate = False # lower levels are not propogated to children
+    # removing any current handles
     if log.hasHandlers():
         log.handlers.clear()
-    # stream output
-    sh = logging.StreamHandler(stream=sys.stdout)
-    sh.setLevel(logging.DEBUG)
-    sh_format = logging.Formatter("%(message)s")
-    sh.setFormatter(sh_format)
-    log.addHandler(sh)
+        
     # file output
     f = logging.FileHandler("sensors.log")
-    f.setLevel(logging.DEBUG)
+    f.setLevel(level)
     f_format = logging.Formatter("%(asctime)s - %(levelname)s\n%(message)s")
     f.setFormatter(f_format)
     log.addHandler(f)
+
     return log
 
 if __name__ == "__main__":
-    log = setup_logger(logging.INFO)
+    log = setup_logger(logging.ERROR)
     beacon = '00'
     asyncio.run(main(beacon = beacon))

--- a/bevobeacon-iaq/sensirion.py
+++ b/bevobeacon-iaq/sensirion.py
@@ -44,7 +44,7 @@ class SPS30:
             sps.read_measured_values()
             pm = sps.dict_values
         except Exception as e:
-            print("Error reading from sensors:", e)
+            # error reading from sensors
             pm = {
                 "nc0p5": np.nan,
                 "nc1p0": np.nan,

--- a/reboot_install.sh
+++ b/reboot_install.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-sudo /bin/bash -c 'echo "59 23 * * * root sh /home/pi/bevo_iaq/reboot.sh" >> /etc/crontab'


### PR DESCRIPTION
Too much logging, not enough space.

Turns out there were some issues that caused the beacons to be _extremely_ verbose on the point of taking up all the space. This update reduces the amount of and type of logging written out to files namely by:
* ❌ **Errors only**: increased logging level to ERROR rather than INFO
* 🖨️ **NO print statements**: They only take up the device's memory. 
* ✏️ **Delete lingering loggers**: Included a line to remove any handles that are currently active before creating the new handle thus removing any duplicate logging.

These updates, in addition to perhaps including some regular log purging, should solve the storage issue. Not sure _exactly_ what prompted the error, but I would guess it was in the `display.py` script since that is the only script I added logging to. `main.py` should have been untouched in terms of logging at least. Still, best to reduce logging as much as possible if it isn't providing merit. 